### PR TITLE
Travis smoothing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,25 @@
 language: c
-sudo: true
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - python-pip
+
 cache:
   directories:
   - "/home/travis/devkitPro"
+  - "/home/travis/pip-requirements"
 before_install:
 - export DEVKITPRO=/home/travis/devkitPro
 - export BUILD_DIR=/home/travis/build_dir
 - export DEVKITARM=${DEVKITPRO}/devkitARM
-- mkdir -p $TRAVIS_BUILD_DIR/out
-- sudo apt-get install python-pip
-- sudo pip install cryptography
-- sudo pip install git+https://github.com/TuxSH/firmtool.git
-- mkdir -p $DEVKITPRO
+- export PIP_REQUIREMENTS=/home/travis/pip-requirements
+- mkdir -p $TRAVIS_BUILD_DIR/out $DEVKITPRO $BUILD_DIR $PIP_REQUIREMENTS
+- pip install --target $PIP_REQUIREMENTS -U -r requirements.txt
 - cd $DEVKITPRO/..
 - wget -O devkitpro.tar.gz -N --no-check-certificate https://www.dropbox.com/s/vl18h63rolio56k/devkitpro.tar.gz?dl=1
 - tar -xvf devkitpro.tar.gz
-- mkdir -p $BUILD_DIR
 - cd $BUILD_DIR
 - git clone https://github.com/AuroraWright/Luma3DS.git
 install:
@@ -26,8 +30,6 @@ script:
 after_success:
 - mv -v $BUILD_DIR/Luma3DS/out/* $TRAVIS_BUILD_DIR/out/
 before_deploy:
-- git config --local user.name "Pirater12"
-- git config --local user.email "pokemonemerald0@gmail.com"
 - git tag "$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)"
 deploy:
   provider: releases

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+cryptography
+git+https://github.com/TuxSH/firmtool.git


### PR DESCRIPTION
- sudo: false is now used, all uses of sudo have been replaced with commands that dont need sudo/plugins. This
considerably speeds up builds/machine boot time
- for installing python-pip, the Travis CI apt addon is used (see above for why)
- pip installation directory is now cached and doesn't need sudo
- pip installs to /home/travis/pip-requirements (for caching)
- reduced amount of mkdir -p commands to one command
- removed pirater12s email address and username from the Travis script (Travis CI has its own username set up by default that indicates the build was made with Travis)